### PR TITLE
[FE] feat : 상인정보, 대여내역페이지 레이아웃 구현

### DIFF
--- a/frontend/src/components/common/NavTemp.tsx
+++ b/frontend/src/components/common/NavTemp.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import { AiOutlineSearch } from 'react-icons/ai';
-import { TbBook } from 'react-icons/tb';
-import { BsChatDots } from 'react-icons/bs';
-import { FiUser } from 'react-icons/fi';
+import {
+	HiOutlineSearch,
+	HiOutlineBookOpen,
+	HiOutlineChat,
+	HiOutlineUser,
+	HiHome,
+} from 'react-icons/hi';
 import home from '../../assets/image/home.png';
 import { Link } from 'react-router-dom';
 
@@ -19,14 +22,14 @@ const NavTemp = () => {
 	const [menus, setMenus] = useState<MenuProps[]>([
 		{
 			id: 0,
-			icon: <AiOutlineSearch size="30" />,
+			icon: <HiOutlineSearch size="30" />,
 			text: '검색',
 			selected: false,
 			path: '/books/search',
 		},
 		{
 			id: 1,
-			icon: <TbBook size="30" />,
+			icon: <HiOutlineBookOpen size="30" />,
 			text: '대여목록',
 			selected: false,
 			path: '/history',
@@ -40,14 +43,14 @@ const NavTemp = () => {
 		},
 		{
 			id: 3,
-			icon: <BsChatDots size="30" />,
+			icon: <HiOutlineChat size="30" />,
 			text: '채팅',
 			selected: false,
 			path: '/chats',
 		},
 		{
 			id: 4,
-			icon: <FiUser size="30" />,
+			icon: <HiOutlineUser size="30" />,
 			text: '마이페이지',
 			selected: false,
 			path: '/profile',
@@ -68,13 +71,12 @@ const NavTemp = () => {
 			{menus.map(menu => {
 				const { id, icon, text, selected, path } = menu;
 				return (
-					<Box
-						key={id}
-						selected={selected}
-						onClick={() => handleChangeMenu(id)}>
-						{icon}
-						<Link to={path}>{text}</Link>
-					</Box>
+					<Link to={path} key={id}>
+						<Box selected={selected} onClick={() => handleChangeMenu(id)}>
+							{icon}
+							{text}
+						</Box>
+					</Link>
 				);
 			})}
 		</Container>
@@ -85,8 +87,8 @@ export default NavTemp;
 
 const Container = styled.div`
 	position: fixed;
-	/* width: 100vw; */
-	min-width: 425px;
+	width: 100%;
+	/* max-width: 425px; */
 	display: flex;
 	justify-content: space-around;
 	align-items: center;
@@ -101,5 +103,8 @@ interface BoxProps {
 }
 
 const Box = styled.div<BoxProps>`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 	color: ${props => (props.selected ? '#26795D' : '#000000')};
 `;

--- a/frontend/src/pages/BooksListPage.tsx
+++ b/frontend/src/pages/BooksListPage.tsx
@@ -1,5 +1,20 @@
+import styled from 'styled-components';
+import BookList from '../components/common/BookList';
+
 function BooksListPage() {
-	return <h1>BooksListPage</h1>;
+	return (
+		<BookInfoBox>
+			<BookList />
+		</BookInfoBox>
+	);
 }
+
+const BookInfoBox = styled.div`
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-start;
+`;
 
 export default BooksListPage;

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,26 +1,57 @@
 import { Link } from 'react-router-dom';
 import { Outlet } from 'react-router-dom';
+import React from 'react';
+import styled from 'styled-components';
 
-function HistoryPage() {
+const HistoryPage = () => {
 	return (
-		<>
-			<h1>HistoryPage</h1>
-			<ul>
-				<li>
-					<Link to={''}>
-						<span>RentHistoryPage</span>
-					</Link>
-				</li>
-				<li>
-					<Link to={'lend'}>
-						<span>LendHistoryPage</span>
-					</Link>
-				</li>
-			</ul>
-			<span>현재 탭: </span>
+		<Layout>
+			<Title>대여 목록</Title>
+			<div
+				style={{
+					display: 'flex',
+					width: '100%',
+					justifyContent: 'space-evenly',
+					marginTop: '1rem',
+				}}>
+				<Tab>빌린 책</Tab>
+				<Tab>빌려준 책</Tab>
+			</div>
 			<Outlet />
-		</>
+		</Layout>
 	);
-}
+};
+
+const Layout = styled.div`
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	padding: 1rem;
+	h2 {
+		font-size: 2rem;
+		margin-bottom: 1rem;
+	}
+`;
+
+const Title = styled.p`
+	width: 100%;
+	font-size: 2.5rem;
+	text-align: center;
+	padding-bottom: 1rem;
+	border-bottom: 1px solid #a7a7a7;
+`;
+
+const Tab = styled.button`
+	padding: 0.8rem 3rem;
+	background-color: ${props => props.theme.colors.main};
+	border: none;
+	border-radius: 5px;
+	box-shadow: nonoe;
+	color: white;
+	cursor: pointer;
+	/* display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap; */
+`;
 
 export default HistoryPage;

--- a/frontend/src/pages/LayoutTemp.tsx
+++ b/frontend/src/pages/LayoutTemp.tsx
@@ -4,12 +4,44 @@ import styled from 'styled-components';
 import NavBar from '../components/common/NavBar';
 import NavTemp from '../components/common/NavTemp';
 
+const LayoutTemp = () => {
+	return (
+		<Main>
+			<Body>
+				<Outlet />
+			</Body>
+			<NavTemp />
+			{/* <Nav>
+					<li>
+					<Link to={'/books/search'}>검색</Link>
+					</li>
+					<li>
+					<Link to={'/history'}>대여목록</Link>
+					</li>
+					<li>
+						<Link to={'/books'}>홈</Link>
+						</li>
+						<li>
+						<Link to={'/chats'}>채팅</Link>
+						</li>
+						<li>
+						<Link to={'/profile'}>마이페이지</Link>
+						</li>
+					</Nav> */}
+		</Main>
+	);
+};
 const Main = styled.div`
 	height: 100%;
 	width: 100%;
 
 	display: flex;
 	justify-content: center;
+`;
+
+const Body = styled.div`
+	width: 100%;
+	padding-bottom: 40px;
 `;
 
 const Nav = styled.ul`
@@ -22,33 +54,5 @@ const Nav = styled.ul`
 		margin: 0px 5px;
 	}
 `;
-
-const LayoutTemp = () => {
-	return (
-		<div>
-			<Main>
-				<Outlet />
-				<NavTemp />
-				{/* <Nav>
-					<li>
-						<Link to={'/books/search'}>검색</Link>
-					</li>
-					<li>
-						<Link to={'/history'}>대여목록</Link>
-					</li>
-					<li>
-						<Link to={'/books'}>홈</Link>
-					</li>
-					<li>
-						<Link to={'/chats'}>채팅</Link>
-					</li>
-					<li>
-						<Link to={'/profile'}>마이페이지</Link>
-					</li>
-				</Nav> */}
-			</Main>
-		</div>
-	);
-};
 
 export default LayoutTemp;

--- a/frontend/src/pages/LendHistoryPage.tsx
+++ b/frontend/src/pages/LendHistoryPage.tsx
@@ -1,5 +1,52 @@
-function LendHistoryPage() {
-	return <h1>LendHistoryPage</h1>;
-}
+import styled from 'styled-components';
+import dummyImage from '../assets/image/dummy.png';
+import BookList from '../components/common/BookList';
+
+const LendHistoryPage = () => {
+	return <Layout>빌려준 책 목록</Layout>;
+};
 
 export default LendHistoryPage;
+
+const Layout = styled.div`
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	min-width: 425px;
+	padding: 1rem;
+	h2 {
+		font-size: 2rem;
+		margin-bottom: 1rem;
+	}
+`;
+
+const Title = styled.p`
+	width: 100%;
+	font-size: 2.5rem;
+	text-align: center;
+	padding-bottom: 1rem;
+	border-bottom: 1px solid #a7a7a7;
+`;
+
+const ProfileBox = styled.div`
+	width: 80%;
+	display: flex;
+	padding: 1.2rem;
+	border: 1px solid #eaeaea;
+	margin: 1rem 0;
+`;
+
+const UserInfoBox = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-left: 2rem;
+`;
+
+const BookInfoBox = styled.div`
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: flex-start;
+`;

--- a/frontend/src/pages/MerchantPage.tsx
+++ b/frontend/src/pages/MerchantPage.tsx
@@ -1,26 +1,60 @@
 import { Link } from 'react-router-dom';
 import { Outlet } from 'react-router-dom';
+import styled from 'styled-components';
+import dummyImage from '../assets/image/dummy.png';
 
 function MerchantPage() {
 	return (
-		<>
-			<h1>MerchantPage</h1>
-			<ul>
-				<li>
-					<Link to={''}>
-						<span>BooksListPage</span>
-					</Link>
-				</li>
-				<li>
-					<Link to={'review-list'}>
-						<span>ReviewListPage</span>
-					</Link>
-				</li>
-			</ul>
-			<span>현재 탭: </span>
+		<Layout>
+			<Title>상인 정보</Title>
+			<ProfileBox>
+				<img src={dummyImage} alt="dummy" width={80} height={100} />
+				<UserInfoBox>
+					<p>닉네임: 홍길동</p>
+					<p>주거래 동네: 강남</p>
+					<p>빌려주는 도서 수: 3</p>
+					<p>평점(평균): 별별별별별</p>
+				</UserInfoBox>
+			</ProfileBox>
+			<h2>책목록</h2>
 			<Outlet />
-		</>
+		</Layout>
 	);
 }
+
+const Layout = styled.div`
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	padding: 1rem;
+	min-width: 90%;
+	h2 {
+		font-size: 2rem;
+		margin-bottom: 1rem;
+	}
+`;
+
+const Title = styled.p`
+	width: 100%;
+	font-size: 2.5rem;
+	text-align: center;
+	padding-bottom: 1rem;
+	border-bottom: 1px solid #a7a7a7;
+`;
+
+const ProfileBox = styled.div`
+	width: 80%;
+	display: flex;
+	padding: 1.2rem;
+	border: 1px solid #eaeaea;
+	margin: 1rem 0;
+`;
+
+const UserInfoBox = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin-left: 2rem;
+`;
 
 export default MerchantPage;

--- a/frontend/src/pages/RentHistoryPage.tsx
+++ b/frontend/src/pages/RentHistoryPage.tsx
@@ -1,5 +1,39 @@
-function RentHistoryPage() {
-	return <h1>RentHistoryPage</h1>;
-}
+import styled from 'styled-components';
+
+const RentHistoryPage = () => {
+	return <Layout>빌린 책 목록</Layout>;
+};
 
 export default RentHistoryPage;
+
+const Layout = styled.div`
+	display: flex;
+	align-items: center;
+	flex-direction: column;
+	padding: 1rem;
+	h2 {
+		font-size: 2rem;
+		margin-bottom: 1rem;
+	}
+`;
+
+const Title = styled.p`
+	width: 100%;
+	font-size: 2.5rem;
+	text-align: center;
+	padding-bottom: 1rem;
+	border-bottom: 1px solid #a7a7a7;
+`;
+
+const Tab = styled.button`
+	padding: 0.8rem 3rem;
+	background-color: ${props => props.theme.colors.main};
+	border: none;
+	border-radius: 5px;
+	box-shadow: nonoe;
+	color: white;
+	cursor: pointer;
+	/* display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap; */
+`;

--- a/frontend/src/styles/globalStyles.ts
+++ b/frontend/src/styles/globalStyles.ts
@@ -41,6 +41,10 @@ const GlobalStyle = createGlobalStyle`
     /* overflow: overlay; */
     overflow-x: hidden;
   }
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
   /* HTML5 display-role reset for older browsers */
   article, aside, details, figcaption, figure, 
   footer, header, hgroup, menu, nav, section {


### PR DESCRIPTION
1. a 링크 css 초기화
2. navbar의 position: fixed로 인해 body부분 컨텐츠가 가려지는 문제가 있어 Layout에 Body 태그를 추가해서 해결했습니다.
3. navbar에 Link 태그를 상위로 올려서 아이콘을 클릭해도 페이지 이동이 가능하게 했습니다.