### PR TITLE
[BE] Refactor: Member 도메인 안 엔티티와 request dto 수정

### DIFF
--- a/backend/src/main/java/com/dongnebook/domain/member/domain/Member.java
+++ b/backend/src/main/java/com/dongnebook/domain/member/domain/Member.java
@@ -25,7 +25,7 @@ public class Member {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "member_id", updatable = false)
+	@Column(name = "id", updatable = false)
 	private Long id;
 
 	@Column(name = "user_id", nullable = false, unique = true)

--- a/backend/src/main/java/com/dongnebook/domain/member/domain/Member.java
+++ b/backend/src/main/java/com/dongnebook/domain/member/domain/Member.java
@@ -7,10 +7,12 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.validation.constraints.Min;
 
 import com.dongnebook.domain.member.dto.Request.MemberRegisterRequest;
 import com.dongnebook.domain.model.Location;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,52 +20,53 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "member")
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "memberId", updatable = false)
-	private Long memberId;
+	@Column(name = "member_id", updatable = false)
+	private Long id;
 
-	@Column(name = "id", nullable = false, unique = true)
-	private String id;
+	@Column(name = "user_id", nullable = false, unique = true)
+	private String userId;
 
+	@Min(value = 8)
 	@Column(name = "password", nullable = false)
 	private String password;
 
-	@Column(name = "name", nullable = false)
-	private String name;
+	@Column(name = "nickname", nullable = false)
+	private String nickname;
 
 	@Embedded
 	private Location location;
 
-	@Column(name = "avatarUrl")
+	@Column(name = "avatar_url")
 	private String avatarUrl;
 
-	@Column(name = "AvgGrade")
-	private Long AvgGrade;
+	@Column(name = "avg_grade")
+	private Long avgGrade;
 
-	@Column(name = "totalBookCount")
+	@Column(name = "total_book_count")
 	private Long totalBookCount;
 
 	@Builder
-	public Member(String id, String password, String name, Location location, String avatarUrl, Long avgGrade,
-		Long totalBookCount) {
-		this.id = id;
+	public Member(String userId, String password, String nickname, Location location, String avatarUrl, Long avgGrade,
+				  Long totalBookCount) {
+		this.userId = userId;
 		this.password = password;
-		this.name = name;
+		this.nickname = nickname;
 		this.avatarUrl = avatarUrl;
 		this.location = location;
-		this.AvgGrade = avgGrade;
+		this.avgGrade = avgGrade;
 		this.totalBookCount = totalBookCount;
 	}
 
 	public static Member create(MemberRegisterRequest memberRegisterRequest) {
 		return Member.builder()
-			.id(memberRegisterRequest.getId())
-			.name(memberRegisterRequest.getName())
-			.password(memberRegisterRequest.getPassword())
-			.build();
+				.userId(memberRegisterRequest.getUserId())
+				.nickname(memberRegisterRequest.getNickname())
+				.password(memberRegisterRequest.getPassword())
+				.build();
 	}
 }

--- a/backend/src/main/java/com/dongnebook/domain/member/dto/Request/MemberLoginRequest.java
+++ b/backend/src/main/java/com/dongnebook/domain/member/dto/Request/MemberLoginRequest.java
@@ -9,14 +9,14 @@ import lombok.Getter;
 public class MemberLoginRequest {
 
 	@NotBlank
-	private String id;
+	private String userId;
 
 	@NotBlank
 	private String password;
 
 	@Builder
-	public MemberLoginRequest(String id, String password) {
-		this.id = id;
+	public MemberLoginRequest(String userId, String password) {
+		this.userId = userId;
 		this.password = password;
 	}
 }

--- a/backend/src/main/java/com/dongnebook/domain/member/dto/Request/MemberRegisterRequest.java
+++ b/backend/src/main/java/com/dongnebook/domain/member/dto/Request/MemberRegisterRequest.java
@@ -1,6 +1,7 @@
 package com.dongnebook.domain.member.dto.Request;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -8,19 +9,21 @@ import lombok.Getter;
 @Getter
 public class MemberRegisterRequest {
 
-	@NotBlank
-	private String id;
+	@NotBlank(message = "아이디는 필수 입력 값입니다.")
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]$", message = "아이디는 영문과 숫자의 조합입니다.")
+	private String userId;
 
-	@NotBlank
+	@NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*?[#?!@$%^&*-])[A-Za-z\\d#?!@$%^&*-]{8,}$", message = "비밀번호는 영문과 특수문자를 포함한 8자리 이상이어야 합니다.")
 	private String password;
 
-	@NotBlank
-	private String name;
+	@NotBlank(message = "닉네임은 필수 입력 값입니다.")
+	private String nickname;
 
 	@Builder
-	public MemberRegisterRequest(String id, String password, String name) {
-		this.id = id;
-		this.name = name;
+	public MemberRegisterRequest(String userId, String password, String nickname) {
+		this.userId = userId;
+		this.nickname = nickname;
 		this.password = password;
 	}
 }


### PR DESCRIPTION
- Member 엔티티 테이블명&칼럼명 소문자 snakecase로 변경. 필드명 id->userId name->nickname으로 변경.  accesslevel=protected 추가
- MemberRegisterRequest dto의 아이디/패스워드 유효성검사 추가