### PR TITLE
[BE] Refactor: 테스트 관련 리팩토링 & CI/CD 관련 설정 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,16 +31,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
         
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -83,16 +73,7 @@ jobs:
           title: Test Coverage Report
           paths: ./backend/jacoco/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 30
-          min-coverage-changed-files: 30
-
-      - name: Cleanup Gradle Cache
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        if: ${{ always() }}
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
+          min-coverage-overall: 50
 
       - name: Make zip file
         run: zip -r ./main-015-deploy.zip .

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,6 +32,16 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
         
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+        
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
         working-directory: ./backend/
@@ -74,6 +84,14 @@ jobs:
           paths: ./backend/jacoco/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 50
+
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        if: ${{ always() }}
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties
 
       - name: Make zip file
         run: zip -r ./main-015-deploy.zip .

--- a/.github/workflows/testAfterPR.yml
+++ b/.github/workflows/testAfterPR.yml
@@ -8,9 +8,6 @@
 name: Test After PR & push
 
 on:
-  push:
-    paths: [ 'backend/**', '.github/workflows/gradle.yml', '.github/workflows/testBeforeMerge.yml' ]
-    branches: [ 'main' , 'dev' ]
   pull_request:
     paths: [ 'backend/**', '.github/workflows/gradle.yml', '.github/workflows/testBeforeMerge.yml' ]
     branches: [ 'main' , 'dev' ]
@@ -28,16 +25,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -60,13 +47,5 @@ jobs:
           title: Test Coverage Report
           paths: ./backend/jacoco/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 30
-          min-coverage-changed-files: 30
+          min-coverage-overall: 50
           
-      - name: Cleanup Gradle Cache
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        if: ${{ always() }}
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/testAfterPR.yml
+++ b/.github/workflows/testAfterPR.yml
@@ -26,6 +26,16 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
         working-directory: ./backend/
@@ -48,4 +58,12 @@ jobs:
           paths: ./backend/jacoco/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 50
+          
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        if: ${{ always() }}
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties
           

--- a/.github/workflows/testAfterPR.yml
+++ b/.github/workflows/testAfterPR.yml
@@ -5,7 +5,7 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
-name: Test After PR & push
+name: Test After PR
 
 on:
   pull_request:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -79,6 +79,52 @@ jacocoTestReport {
         xml.destination file("jacoco/jacoco.xml")
 
     }
+
+    def Qdomains = []
+    for (qPattern in '**/QA'..'**/QZ') {
+        Qdomains.add(qPattern + '*')
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            "**/*Application*",
+                            "**/*Config*",
+                            "**/*Dto*",
+                            "**/*Request*",
+                            "**/*Response*",
+                            "**/*Interceptor*",
+                            "**/*Exception*"
+                    ] + Qdomains)
+                })
+        )
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    def Qdomains = []
+    for (qPattern in '*.QA'..'*.QZ') {
+        Qdomains.add(qPattern + '*')
+    }
+
+    violationRules {
+        rule {
+            element = 'CLASS'
+            enabled = true
+
+            excludes = [
+                    "**.*Application*",
+                    "**.*Config*",
+                    "**.*Dto*",
+                    "**.*Request*",
+                    "**.*Response*",
+                    "**.*Interceptor*",
+                    "**.*Exception*"
+            ] + Qdomains
+        }
+    }
 }
 
 jacoco {

--- a/backend/lombok.config
+++ b/backend/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/backend/src/main/java/com/dongnebook/domain/rental/repository/RentalQueryRepository.java
+++ b/backend/src/main/java/com/dongnebook/domain/rental/repository/RentalQueryRepository.java
@@ -164,7 +164,7 @@ public class RentalQueryRepository {
         return jpaQueryFactory.selectFrom(rental)
             .innerJoin(rental.customer).fetchJoin()
             .innerJoin(rental.book).fetchJoin()
-            .where(rental.rentalDeadLine.between(start,end),rentalStateEq(String.valueOf(RentalState.RETURN_REVIEWED)))
+            .where(rental.rentalDeadLine.between(start,end),rentalStateEq(String.valueOf(RentalState.BEING_RENTED)))
             .fetch();
     }
 }

--- a/backend/src/test/java/com/dongnebook/domain/rental/application/RentalServiceTest2.java
+++ b/backend/src/test/java/com/dongnebook/domain/rental/application/RentalServiceTest2.java
@@ -108,7 +108,6 @@ public class RentalServiceTest2 {
         Book book = new Book(1L, new BookProduct(), "aaa@abc.com", "기본이 중요하다", Money.of(1000), new Location(37.5340, 126.7064), member2);
         when(bookQueryService.getWithMerchantByBookId(bookId)).thenReturn(book);
 
-//        doNothing().when(alarmService).sendAlarm(Mockito.any(Member.class), Mockito.any(Book.class), Mockito.any(AlarmType.class));
 
         // when & then
         assertDoesNotThrow(() -> rentalService.createRental(bookId, customerId));

--- a/backend/src/test/java/com/dongnebook/domain/rental/repository/RentalQueryRepositoryTest.java
+++ b/backend/src/test/java/com/dongnebook/domain/rental/repository/RentalQueryRepositoryTest.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 @ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({TestConfig.class, DatabaseCleaner.class})
@@ -47,8 +47,6 @@ public class RentalQueryRepositoryTest {
     BookCommandRepository bookCommandRepository;
     @Autowired
     RentalRepository rentalRepository;
-//    @PersistenceContext
-//    EntityManager entityManager;
 
     @BeforeEach
     public void setting() {
@@ -184,7 +182,7 @@ public class RentalQueryRepositoryTest {
 
         Rental rental3 = Rental.builder()
                 .rentalDeadLine(LocalDateTime.now().withHour(23).withMinute(59).withSecond(59))
-                .rentalState(RentalState.RETURN_REVIEWED)
+                .rentalState(RentalState.BEING_RENTED)
                 .merchantId(savedMerchant.getId())
                 .book(savedBook3)
                 .customer(savedCustomer)

--- a/backend/src/test/java/com/dongnebook/domain/rental/repository/RentalRepositoryTest.java
+++ b/backend/src/test/java/com/dongnebook/domain/rental/repository/RentalRepositoryTest.java
@@ -5,22 +5,27 @@ import com.dongnebook.domain.book.domain.Book;
 import com.dongnebook.domain.book.domain.BookProduct;
 import com.dongnebook.domain.book.domain.Money;
 import com.dongnebook.domain.member.domain.Member;
-import com.dongnebook.domain.member.dto.request.MemberRegisterRequest;
 import com.dongnebook.domain.member.repository.MemberRepository;
 import com.dongnebook.domain.model.Location;
 import com.dongnebook.domain.rental.domain.Rental;
 import com.dongnebook.domain.rental.domain.RentalState;
+import com.dongnebook.support.DataClearExtension;
+import com.dongnebook.support.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
+@Import(DatabaseCleaner.class)
+@ExtendWith(DataClearExtension.class)
 public class RentalRepositoryTest {
     @Autowired
     private RentalRepository rentalRepository;
@@ -68,86 +73,11 @@ public class RentalRepositoryTest {
                 .book(savedBook)
                 .customer(savedMember)
                 .build();
-
     }
-
-//      안 되는 애
-//    @Test
-//    public void saveRentalTestOriginal() {
-//        // given
-//        Member merchant = new Member(1L, "test1", "tester1", new Location(37.5340, 126.7064), "anywhere", "abc1@abc.com");
-//        BookProduct bookProduct = new BookProduct("수학의 정석", "남궁성", "도우출판");
-//        Money money = Money.of(1000);
-//        Location location = new Location(37.5340, 126.7064);
-//        Book book = new Book(1L, bookProduct, "aaa@abc.com", "기본이 중요하다", money, location, merchant);
-//        Member customer = new Member(2L, "test2", "tester2", new Location(37.5340, 126.7064), "anywhere", "abc2@abc.com");
-//
-//        // when
-//        Rental savedRental = rentalRepository.save(Rental.create(book, customer));
-//
-//        // then
-//        assertNotNull(savedRental);
-//    }
-
-//    되는 애 (다만, 뒤에 것이 다음 테스트와 일관성이 있어서 그렇게 만듦)
-//    @Test
-//    public void saveRentalTestOriginal2() {
-//        // given
-//        MemberRegisterRequest memberRegisterRequest1 = new MemberRegisterRequest("merchant", "12341234", "nickname1");
-//        Member merchant = Member.create(memberRegisterRequest1);
-//        Member savedMerchant = memberRepository.save(merchant);
-//        BookProduct bookProduct = new BookProduct("수학의 정석", "남궁성", "도우출판");
-//        Book book = new Book(1L, bookProduct, "aaa@abc.com", "기본이 중요하다", Money.of(1000), new Location(37.5340, 126.7064), savedMerchant);
-//        Book savedBook = bookCommandRepository.save(book);
-//
-//        MemberRegisterRequest memberRegisterRequest2 = new MemberRegisterRequest("customer", "12341234", "nickname2");
-//        Member customer = Member.create(memberRegisterRequest2);
-//        Member savedCustomer = memberRepository.save(customer);
-//
-//        Rental rental = Rental.create(savedBook, savedCustomer);
-//
-//        // when
-//        Rental savedRental = rentalRepository.save(rental);
-//
-//        // then
-//        assertNotNull(savedRental);
-//        assertEquals(savedRental.getRentalDeadLine(), rental.getRentalDeadLine());
-//        assertEquals(savedRental.getRentalState(), rental.getRentalState());
-//        assertEquals(savedRental.getMerchantId(), rental.getMerchantId());
-//        assertEquals(savedRental.getBook(), rental.getBook());
-//        assertEquals(savedRental.getCustomer(), rental.getCustomer());
-//    }
 
     @Test
     public void saveRentalTest() {
         // given
-//        Member member1 = Member.builder()
-//                .userId("test")
-//                .avatarUrl("aaa@aa.com")
-//                .nickname("tester")
-//                .password("12341234")
-//                .build();
-//        Member savedMember = memberRepository.save(member1);
-//
-//        BookProduct bookProduct = new BookProduct("수학의 정석1", "남궁성", "도우출판");
-//        Book book = Book.builder()
-//                .id(1L)
-//                .bookProduct(bookProduct)
-//                .imgUrl("aaa@abc.com")
-//                .description("기본이 중요하다")
-//                .rentalFee(Money.of(1000))
-//                .location(new Location(37.5340, 126.7064))
-//                .member(savedMember)
-//                .build();
-//        Book savedBook = bookCommandRepository.save(book);
-//
-//        Member member2 = Member.builder()
-//                .userId("test2")
-//                .avatarUrl("aaa@aa.com")
-//                .nickname("tester2")
-//                .password("12341234")
-//                .build();
-//        Member savedMember2 = memberRepository.save(member2);
 
         // when
         Rental savedRental = rentalRepository.save(rental);
@@ -161,74 +91,13 @@ public class RentalRepositoryTest {
         assertEquals(savedRental.getCustomer(), rental.getCustomer());
     }
 
-//  개별로 하면 되지만, class 단위로 하면 안 되는 애 (이름 상관없이)
-//    @Test
-//    public void rentalFindByIdTestOriginal() {
-//        // given
-//        MemberRegisterRequest memberRegisterRequest1 = new MemberRegisterRequest("merchant", "12341234", "nickname1");
-//        Member merchant = Member.create(memberRegisterRequest1);
-//        Member savedMerchant = memberRepository.save(merchant);
-//        BookProduct bookProduct = new BookProduct("수학의 정석1", "남궁성", "도우출판");
-//        Book book = new Book(1L, bookProduct, "aaa@abc.com", "기본이 중요하다", Money.of(1000), new Location(37.5340, 126.7064), savedMerchant);
-//        Book savedBook = bookCommandRepository.save(book);
-//
-//        MemberRegisterRequest memberRegisterRequest2 = new MemberRegisterRequest("customer", "12341234", "nickname2");
-//        Member customer = Member.create(memberRegisterRequest2);
-//        Member savedCustomer = memberRepository.save(customer);
-//
-//        Rental rental = Rental.create(savedBook, savedCustomer);
-//
-//        // when
-//        rentalRepository.save(rental);
-//        Optional<Rental> foundRental = rentalRepository.findById(1L);
-//
-//        // then
-//        assertTrue(foundRental.isPresent());
-//        assertEquals(foundRental.get().getRentalDeadLine(), rental.getRentalDeadLine());
-//        assertEquals(foundRental.get().getRentalState(), rental.getRentalState());
-//        assertEquals(foundRental.get().getMerchantId(), rental.getMerchantId());
-//        assertEquals(foundRental.get().getBook(), rental.getBook());
-//        assertEquals(foundRental.get().getCustomer(), rental.getCustomer());
-//    }
-
-    // 이름이 findByIdTset면 안되는 애
     @Test
-//    public void findByIdTest() {
     public void rentalFindByIdTest() {
         // given
-//        Member member1 = Member.builder()
-//                .userId("test")
-//                .avatarUrl("aaa@aa.com")
-//                .nickname("tester")
-//                .password("12341234")
-//                .build();
-//        Member savedMember = memberRepository.save(member1);
-//
-//        BookProduct bookProduct = new BookProduct("수학의 정석1", "남궁성", "도우출판");
-//        Book book = Book.builder()
-//                .id(1L)
-//                .bookProduct(bookProduct)
-//                .imgUrl("aaa@abc.com")
-//                .description("기본이 중요하다")
-//                .rentalFee(Money.of(1000))
-//                .location(new Location(37.5340, 126.7064))
-//                .member(savedMember)
-//                .build();
-//        Book savedBook = bookCommandRepository.save(book);
-//
-//        Member member2 = Member.builder()
-//                .userId("test2")
-//                .avatarUrl("aaa@aa.com")
-//                .nickname("tester2")
-//                .password("12341234")
-//                .build();
-//        Member savedMember2 = memberRepository.save(member2);
-
-        // given
+        Rental savedRental = rentalRepository.save(rental);
 
         // when
-        rentalRepository.save(rental);
-        Optional<Rental> foundRental = rentalRepository.findById(1L);
+        Optional<Rental> foundRental = rentalRepository.findById(savedRental.getId());
 
         // then
         assertTrue(foundRental.isPresent());

--- a/backend/src/test/java/com/dongnebook/domain/reservation/repository/ReservationQueryRepositoryTest.java
+++ b/backend/src/test/java/com/dongnebook/domain/reservation/repository/ReservationQueryRepositoryTest.java
@@ -16,12 +16,10 @@ import com.dongnebook.domain.reservation.dto.response.ReservationInfoResponse;
 import com.dongnebook.global.dto.request.PageRequestImpl;
 import com.dongnebook.support.DataClearExtension;
 import com.dongnebook.support.DatabaseCleaner;
-import com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -33,8 +31,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
-@ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
+@DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({TestConfig.class, DatabaseCleaner.class})
 @ExtendWith(DataClearExtension.class)

--- a/backend/src/test/java/com/dongnebook/domain/reservation/repository/ReservationRepositoryTest.java
+++ b/backend/src/test/java/com/dongnebook/domain/reservation/repository/ReservationRepositoryTest.java
@@ -12,10 +12,14 @@ import com.dongnebook.domain.rental.domain.RentalState;
 import com.dongnebook.domain.rental.repository.RentalRepository;
 import com.dongnebook.domain.reservation.domain.Reservation;
 
+import com.dongnebook.support.DataClearExtension;
+import com.dongnebook.support.DatabaseCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -23,7 +27,9 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
+@Import(DatabaseCleaner.class)
+@ExtendWith(DataClearExtension.class)
 public class ReservationRepositoryTest {
     @Autowired
     private ReservationRepository reservationRepository;

--- a/backend/src/test/java/com/dongnebook/domain/review/repository/ReviewQueryRepositoryTest.java
+++ b/backend/src/test/java/com/dongnebook/domain/review/repository/ReviewQueryRepositoryTest.java
@@ -32,7 +32,7 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 @ImportAutoConfiguration(DataSourceDecoratorAutoConfiguration.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({TestConfig.class, DatabaseCleaner.class})
@@ -62,15 +62,6 @@ public class ReviewQueryRepositoryTest {
 
         BookProduct bookProduct = new BookProduct("자바의 정석", "남궁성", "도우출판");
         Book book = Book.create(bookProduct, "aaa@abc.com", "기본이 중요하다", Money.of(1000), new Location(37.5340, 126.7064), savedMember);
-        //        Book book = Book.builder()
-//                .id(1L)
-//                .bookProduct(bookProduct)
-//                .imgUrl("aaa@abc.com")
-//                .description("기본이 중요하다")
-//                .rentalFee(Money.of(1000))
-//                .location(new Location(37.5340, 126.7064))
-//                .member(savedMember)
-//                .build();
         Book savedBook = bookCommandRepository.save(book);
 
         Member member2 = Member.builder()
@@ -95,69 +86,6 @@ public class ReviewQueryRepositoryTest {
         Rental savedRental6 = rentalRepository.save(rental6);
         Rental rental7 = Rental.create(savedBook, savedMember2);
         Rental savedRental7 = rentalRepository.save(rental7);
-
-//        Rental rental1 = Rental.builder()
-//                .rentalDeadLine(LocalDateTime.now())
-//                .rentalState(RentalState.TRADING)
-//                .merchantId(savedMember.getId())
-//                .book(savedBook)
-//                .customer(savedMember2)
-//                .build();
-//        rentalRepository.save(rental1);
-//
-//        Rental rental2 = Rental.builder()
-//                .rentalDeadLine(LocalDateTime.now())
-//                .rentalState(RentalState.TRADING)
-//                .merchantId(savedMember.getId())
-//                .book(savedBook)
-//                .customer(savedMember2)
-//                .build();
-//        rentalRepository.save(rental2);
-//
-//        Rental rental3 = Rental.builder()
-//                .rentalDeadLine(LocalDateTime.now())
-//                .rentalState(RentalState.TRADING)
-//                .merchantId(savedMember.getId())
-//                .book(savedBook)
-//                .customer(savedMember2)
-//                .build();
-//        rentalRepository.save(rental3);
-//
-//        Rental rental4 = Rental.builder()
-//                .rentalDeadLine(LocalDateTime.now())
-//                .rentalState(RentalState.TRADING)
-//                .merchantId(savedMember.getId())
-//                .book(savedBook)
-//                .customer(savedMember2)
-//                .build();
-//        rentalRepository.save(rental4);
-//
-//        Rental rental5 = Rental.builder()
-//                .rentalDeadLine(LocalDateTime.now())
-//                .rentalState(RentalState.TRADING)
-//                .merchantId(savedMember.getId())
-//                .book(savedBook)
-//                .customer(savedMember2)
-//                .build();
-//        rentalRepository.save(rental5);
-//
-//        Rental rental6 = Rental.builder()
-//                .rentalDeadLine(LocalDateTime.now())
-//                .rentalState(RentalState.TRADING)
-//                .merchantId(savedMember.getId())
-//                .book(savedBook)
-//                .customer(savedMember2)
-//                .build();
-//        rentalRepository.save(rental6);
-//
-//        Rental rental7 = Rental.builder()
-//                .rentalDeadLine(LocalDateTime.now())
-//                .rentalState(RentalState.TRADING)
-//                .merchantId(savedMember.getId())
-//                .book(savedBook)
-//                .customer(savedMember2)
-//                .build();
-//        rentalRepository.save(rental7);
 
         ReviewRequest reviewRequest = ReviewRequest.builder()
                 .bookId(1L)

--- a/backend/src/test/java/com/dongnebook/domain/review/repository/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/dongnebook/domain/review/repository/ReviewRepositoryTest.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DataJpaTest
+@DataJpaTest(showSql = false)
 public class ReviewRepositoryTest {
     @Autowired
     private ReviewRepository reviewRepository;


### PR DESCRIPTION
## CI/CD
* PRTest, build workflow에서 변경된 파일 커버리지 제한 기준 제거
* PRTest, build workflow에서 merge 가능 커버리지 제한 기준 상향 (30 -> 50)
* PRTest workflow에서 main/dev 브랜치에 push 했을 때에, Test 수행 되는 것 제거

## Feature
* RentalQueryRepository클래스 findAllDeadLineRental메서드의 필터링 조건 변경 및 관련 테스트 수정

## Test
* Rental, Reservation, Review 도메인 불필요 주석 제거
* Rental, Reservation, Review 도메인 필요 어노테이션 추가
* jacoco 테스트 커버리지 측정 대상에서 불필요항목 제거
   - Config 클래스
   - Dto 클래스
   - Response/Request 클래스
   - Interceptor 클래스
   - Exception 
   - Q도메인 클래스 
   - Lombok 에너테이션에 의해 자동 생성되는 것들 (getter, 생성자.. 등등)
